### PR TITLE
Header View

### DIFF
--- a/RecipesTracker/Components/HeaderView.swift
+++ b/RecipesTracker/Components/HeaderView.swift
@@ -1,0 +1,38 @@
+//
+//  HeaderView.swift
+//  RecipesTracker
+//
+//  Created by Pablo Borsone on 19/02/24.
+//
+
+import SwiftUI
+
+struct HeaderView: View {
+    let model: Header
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text(model.title)
+                    .font(.largeTitle)
+                    .fontDesign(.rounded)
+                    .bold()
+                if let subtitle = model.subtitle {
+                    Text(subtitle)
+                        .font(.callout)
+                        .fontDesign(.rounded)
+                        .multilineTextAlignment(.leading)
+                }
+            }
+            Spacer()
+            Button(model.buttonTitle, action: {})
+                .buttonStyle(.borderedProminent)
+                .tint(.black)
+                .controlSize(.extraLarge)
+        }
+    }
+}
+
+#Preview {
+    HeaderView(model: .headerSample)
+}

--- a/RecipesTracker/Models/Header.swift
+++ b/RecipesTracker/Models/Header.swift
@@ -1,0 +1,18 @@
+//
+//  Header.swift
+//  RecipesTracker
+//
+//  Created by Pablo Borsone on 19/02/24.
+//
+
+import Foundation
+
+struct Header {
+    let title: String
+    let subtitle: String?
+    let buttonTitle: String
+}
+
+extension Header {
+    static var headerSample: Self { .init(title: "Featured", subtitle: "We have prepared the best food for you", buttonTitle: "View all") }
+}

--- a/RecipesTracker/ViewModel/HeaderViewModel.swift
+++ b/RecipesTracker/ViewModel/HeaderViewModel.swift
@@ -1,0 +1,27 @@
+//
+//  HeaderViewModel.swift
+//  RecipesTracker
+//
+//  Created by Pablo Borsone on 20/02/24.
+//
+
+import Combine
+
+final class HeaderViewModel: ObservableObject {
+    @Published var title = ""
+    var subscriptions = Set<AnyCancellable>()
+
+    init(title: String = "", subscriptions: Set<AnyCancellable> = Set<AnyCancellable>()) {
+        self.title = title
+        self.subscriptions = subscriptions
+        loadTitle()
+    }
+
+    private func loadTitle() {
+        $title
+            .sink { text in
+                print(text)
+            }
+            .store(in: &subscriptions)
+    }
+}


### PR DESCRIPTION
## Overview

This PR introduces the `HeaderView` component, which will display relevant information at the header of the onboarding screen.

### Notes

This PR doesn't map the new file onto the pbxproj file, but that's intentional. I developed many features before committing then because I was excited, therefore, breaking the pbxproj now would require too much time, so my last PR with this feature will contain its changes.